### PR TITLE
DynamicOnTime: code moved from constructor to `setup`

### DIFF
--- a/components/dynamic_on_time/dynamic_on_time.cpp
+++ b/components/dynamic_on_time/dynamic_on_time.cpp
@@ -30,11 +30,14 @@ DynamicOnTime::DynamicOnTime(
 std::vector<uint8_t> DynamicOnTime::flags_to_days_of_week_(
   bool mon, bool tue, bool wed, bool thu, bool fri, bool sat, bool sun
 ) {
+  // Numeric representation for days of week (starts from Sun internally)
   std::vector<uint8_t> days_of_week = { 1, 2, 3, 4, 5, 6, 7 };
   std::vector<bool> flags = { sun, mon, tue, wed, thu, fri, sat };
 
+  // Translate set of bool flags into vector of corresponding numeric
+  // representation. This uses 'erase-remove' approach (
   // https://en.cppreference.com/w/cpp/algorithm/remove,
-  // https://en.wikipedia.org/wiki/Erase%E2%80%93remove_idiom
+  // https://en.wikipedia.org/wiki/Erase%E2%80%93remove_idiom)
   days_of_week.erase(
     std::remove_if(
       std::begin(days_of_week), std::end(days_of_week),
@@ -45,77 +48,106 @@ std::vector<uint8_t> DynamicOnTime::flags_to_days_of_week_(
 }
 
 void DynamicOnTime::setup() {
-  // Update the schedule initially, ensuring all entities are created before a
-  // callback would be delivered to them
+  // Update the configuration initially, ensuring all entities are created
+  // before a callback would be delivered to them
   this->update_schedule_();
+
+  // Register the cron trigger component
+  App.register_component(this->trigger_);
 
   // The `Number` and `Switch` has no common base type with
   // `add_on_state_callback`, and solutions to properly cast to derived
   // class in single loop over vector of base class instances seemingly imply
   // more code than just two loops
   for (number::Number *comp : {this->hour_, this->minute_}) {
-    comp->add_on_state_callback([this](float value) { this->setup(); });
+    comp->add_on_state_callback([this](float value) {
+      this->update_schedule_();
+    });
   }
 
   for (switch_::Switch *comp : {
     this->mon_, this->tue_, this->wed_, this->thu_, this->fri_, this->sat_,
     this->sun_
   }) {
-    comp->add_on_state_callback([this](float value) { this->setup(); });
+    comp->add_on_state_callback([this](float value) {
+      this->update_schedule_();
+    });
   }
 }
 
 void DynamicOnTime::update_schedule_() {
-  bool to_register = false;
-
-  assert(this->rtc_ != nullptr);
+  // CronTrigger doesn't allow its configuration to be reset programmatically,
+  // so its instance is either created initially, or reinitialized in place if
+  // allocated already
   if (this->trigger_ != nullptr) {
-    // 'placement new', https://en.cppreference.com/w/cpp/language/new
+    // Use 'placement new' (https://en.cppreference.com/w/cpp/language/new) to
+    // reinitialize existing CronTrigger instance in place
     this->trigger_->~CronTrigger();
     new (this->trigger_) time::CronTrigger(this->rtc_);
   } else {
-    to_register = true;
     this->trigger_ = new time::CronTrigger(this->rtc_);
   }
 
-  // Automation
+  // (Re)create the automation instance
   if (this->automation_ != nullptr)
     delete this->automation_;
-
   this->automation_ = new Automation<>(this->trigger_);
+  // Add requested actions to it
   this->automation_->add_actions(this->actions_);
 
+  // Set trigger to fire on zeroth second of configured time
   this->trigger_->add_second(0);
+  // Enable all days of months for the schedule
   for (uint8_t i = 1; i <= 31; i++)
     this->trigger_->add_day_of_month(i);
+  // Same but for months
   for (uint8_t i = 1; i <= 12; i++)
     this->trigger_->add_month(i);
-
+  // Configure hour/minute of the schedule from corresponding components' state
   this->trigger_->add_hour(static_cast<uint8_t>(this->hour_->state));
   this->trigger_->add_minute(static_cast<uint8_t>(this->minute_->state));
-
+  // Similarly but for days of week translating set of components' state to
+  // vector of numeric representation as `CrontTrigger::add_days_of_week()`
+  // requires
   std::vector<uint8_t> days_of_week = this->flags_to_days_of_week_(
     this->mon_->state, this->tue_->state, this->wed_->state,
     this->thu_->state, this->fri_->state, this->sat_->state,
     this->sun_->state);
   this->trigger_->add_days_of_week(days_of_week);
 
-  ESP_LOGCONFIG(
-    tag, "Cron trigger details (updated: %s)",
-    to_register ? "no": "yes");
-  ESP_LOGCONFIG(tag, "Hour: %.0f", this->hour_->state);
-  ESP_LOGCONFIG(tag, "Minute: %.0f", this->minute_->state);
-  ESP_LOGCONFIG(tag, "Mon: %s", this->mon_->state ? "Yes": "No");
-  ESP_LOGCONFIG(tag, "Tue: %s", this->tue_->state ? "Yes": "No");
-  ESP_LOGCONFIG(tag, "Wed: %s", this->wed_->state ? "Yes": "No");
-  ESP_LOGCONFIG(tag, "Thu: %s", this->thu_->state ? "Yes": "No");
-  ESP_LOGCONFIG(tag, "Fri: %s", this->fri_->state ? "Yes": "No");
-  ESP_LOGCONFIG(tag, "Sat: %s", this->sat_->state ? "Yes": "No");
-  ESP_LOGCONFIG(tag, "Sun: %s", this->sun_->state ? "Yes": "No");
+  // Log the configuration
+  this->dump_config();
+}
 
-  if (to_register) {
-    App.register_component(this->trigger_);
-  }
+void DynamicOnTime::dump_config() {
+  ESP_LOGCONFIG(tag, "Cron trigger details:");
+  ESP_LOGCONFIG(
+    tag, "Hour (source: '%s'): %.0f",
+    this->hour_->get_name().c_str(), this->hour_->state);
+  ESP_LOGCONFIG(
+    tag, "Minute (source: '%s'): %.0f",
+    this->minute_->get_name().c_str(), this->minute_->state);
+  ESP_LOGCONFIG(
+    tag, "Mon (source: '%s'): %s",
+    this->mon_->get_name().c_str(), this->mon_->state ? "Yes": "No");
+  ESP_LOGCONFIG(
+    tag, "Tue (source: '%s'): %s",
+    this->tue_->get_name().c_str(), this->tue_->state ? "Yes": "No");
+  ESP_LOGCONFIG(
+    tag, "Wed (source: '%s'): %s",
+    this->wed_->get_name().c_str(), this->wed_->state ? "Yes": "No");
+  ESP_LOGCONFIG(
+    tag, "Thu (source: '%s'): %s",
+    this->thu_->get_name().c_str(), this->thu_->state ? "Yes": "No");
+  ESP_LOGCONFIG(
+    tag, "Fri (source: '%s'): %s",
+    this->fri_->get_name().c_str(), this->fri_->state ? "Yes": "No");
+  ESP_LOGCONFIG(
+    tag, "Sat (source: '%s'): %s",
+    this->sat_->get_name().c_str(), this->sat_->state ? "Yes": "No");
+  ESP_LOGCONFIG(
+    tag, "Sun (source: '%s'): %s",
+    this->sun_->get_name().c_str(), this->sun_->state ? "Yes": "No");
 }
 
 }  // namespace dynamic_on_time

--- a/components/dynamic_on_time/dynamic_on_time.cpp
+++ b/components/dynamic_on_time/dynamic_on_time.cpp
@@ -45,24 +45,24 @@ std::vector<uint8_t> DynamicOnTime::flags_to_days_of_week_(
 }
 
 void DynamicOnTime::setup() {
-  for (auto *comp : std::vector<esphome::EntityBase *>{
-    this->hour_,
-    this->minute_,
+  // Update the schedule initially, ensuring all entities are created before a
+  // callback would be delivered to them
+  this->update_schedule_();
+
+  // The `Number` and `Switch` has no common base type with
+  // `add_on_state_callback`, and solutions to properly cast to derived
+  // class in single loop over vector of base class instances seemingly imply
+  // more code than just two loops
+  for (number::Number *comp : {this->hour_, this->minute_}) {
+    comp->add_on_state_callback([this](float value) { this->setup(); });
+  }
+
+  for (switch_::Switch *comp : {
     this->mon_, this->tue_, this->wed_, this->thu_, this->fri_, this->sat_,
     this->sun_
   }) {
-    // `Switch` and `Number` has no common base class having
-    // `add_on_state_callback` hence iterating over `EntityBase` casting it to
-    // one of types having it
-    reinterpret_cast<esphome::switch_::Switch *>(comp)->add_on_state_callback(
-      [this](float value
-    ) {
-      this->update_schedule_();
-    });
+    comp->add_on_state_callback([this](float value) { this->setup(); });
   }
-
-  // Update the schedule initially
-  this->update_schedule_();
 }
 
 void DynamicOnTime::update_schedule_() {

--- a/components/dynamic_on_time/dynamic_on_time.cpp
+++ b/components/dynamic_on_time/dynamic_on_time.cpp
@@ -45,17 +45,18 @@ std::vector<uint8_t> DynamicOnTime::flags_to_days_of_week_(
 }
 
 void DynamicOnTime::setup() {
-  // `Switch` and `Number` has no common base class having
-  // `add_on_state_callback` hence iterator variable is of `Switch` type
-  // (majority of component pointers), and remaining `Number` are casted to
-  // `Switch` so that single loop is possible
-  for (esphome::switch_::Switch *comp : {
-    reinterpret_cast<esphome::switch_::Switch *>(this->hour_),
-    reinterpret_cast<esphome::switch_::Switch *>(this->minute_),
+  for (auto *comp : std::vector<esphome::EntityBase *>{
+    this->hour_,
+    this->minute_,
     this->mon_, this->tue_, this->wed_, this->thu_, this->fri_, this->sat_,
     this->sun_
   }) {
-    comp->add_on_state_callback([this](float value) {
+    // `Switch` and `Number` has no common base class having
+    // `add_on_state_callback` hence iterating over `EntityBase` casting it to
+    // one of types having it
+    reinterpret_cast<esphome::switch_::Switch *>(comp)->add_on_state_callback(
+      [this](float value
+    ) {
       this->update_schedule_();
     });
   }

--- a/components/dynamic_on_time/dynamic_on_time.h
+++ b/components/dynamic_on_time/dynamic_on_time.h
@@ -20,6 +20,7 @@ class DynamicOnTime : public Component {
     std::vector<esphome::Action<> *>);
 
   void setup() override;
+  void dump_config() override;
 
  protected:
   time::RealTimeClock *rtc_;

--- a/components/dynamic_on_time/dynamic_on_time.h
+++ b/components/dynamic_on_time/dynamic_on_time.h
@@ -38,6 +38,8 @@ class DynamicOnTime : public Component {
 
   std::vector<uint8_t> flags_to_days_of_week_(
     bool, bool, bool, bool, bool, bool, bool);
+
+  void update_schedule_();
 };
 
 }  // namespace dynamic_on_time


### PR DESCRIPTION
* All code initializing component callbacks have been moved from  constructor to `setup()` method, new protected method
  `update_schedule_()` has been introduced to perform actual  instantiation/configuration of `CronTrigger` instance
* Removed `assert` on members since component schema now takes care of  ensuring all configuration options are present
* `DynamicOnTime`: `App.register_component()` is called in `setup`  method only once, to simplify `update_schedule_()`
* Added `DynamicOnTime::dump_config()` method to log configuration