### PR TITLE
feat: Directly inherit from CronTrigger to simplify the logic

### DIFF
--- a/components/dynamic_on_time/__init__.py
+++ b/components/dynamic_on_time/__init__.py
@@ -1,10 +1,10 @@
 '''
-tbd
+Defines the ESPHome integration schema and code generation logic for the
+component.
 '''
 from esphome.const import (
     CONF_ID,
     CONF_ON_TIME,
-    CONF_THEN,
     CONF_HOUR,
     CONF_MINUTE,
 )
@@ -53,14 +53,8 @@ CONFIG_SCHEMA = cv.Schema({
 
 async def to_code(config):
     '''
-    tbd
+    Generates code from YAML definition.
     '''
-    actions = []
-    for conf in config[CONF_ON_TIME]:
-        actions.extend(await automation.build_action_list(
-            conf[CONF_THEN], cg.TemplateArguments(), [])
-        )
-
     var = cg.new_Pvariable(
         config[CONF_ID],
         await cg.get_variable(config[CONF_RTC]),
@@ -74,6 +68,9 @@ async def to_code(config):
         await cg.get_variable(config[CONF_SAT]),
         await cg.get_variable(config[CONF_SUN]),
         await cg.get_variable(config[CONF_DISABLED]),
-        actions,
     )
     await cg.register_component(var, config)
+
+    # Add automations same as CronTrigger does
+    for conf in config[CONF_ON_TIME]:
+        await automation.build_automation(var, cg.TemplateArguments(), conf)

--- a/components/dynamic_on_time/dynamic_on_time.h
+++ b/components/dynamic_on_time/dynamic_on_time.h
@@ -11,13 +11,16 @@
 namespace esphome {
 namespace dynamic_on_time {
 
-class DynamicOnTime : public Component {
+// The component directly inherits from CronTrigger to allow manipulating
+// with its protected/private members. Despite the API might get changed in
+// future, the implementation has better maintainability because of simpler
+// logic.
+class DynamicOnTime : public time::CronTrigger {
  public:
   explicit DynamicOnTime(
     time::RealTimeClock *, number::Number *, number::Number *,
     switch_::Switch *, switch_::Switch *, switch_::Switch *, switch_::Switch *,
-    switch_::Switch *, switch_::Switch *, switch_::Switch *, switch_::Switch *,
-    std::vector<esphome::Action<> *>);
+    switch_::Switch *, switch_::Switch *, switch_::Switch *, switch_::Switch *);
 
   void dump_config() override;
   void setup() override;
@@ -25,20 +28,16 @@ class DynamicOnTime : public Component {
   optional<ESPTime> get_next_schedule();
 
  protected:
-  time::RealTimeClock *rtc_;
-  number::Number *hour_;
-  number::Number *minute_;
-  switch_::Switch *mon_;
-  switch_::Switch *tue_;
-  switch_::Switch *wed_;
-  switch_::Switch *thu_;
-  switch_::Switch *fri_;
-  switch_::Switch *sat_;
-  switch_::Switch *sun_;
-  switch_::Switch *disabled_;
-  std::vector<esphome::Action<> *> actions_;
-  time::CronTrigger *trigger_{nullptr};
-  Automation<> *automation_{nullptr};
+  number::Number *hour_comp_;
+  number::Number *minute_comp_;
+  switch_::Switch *mon_comp_;
+  switch_::Switch *tue_comp_;
+  switch_::Switch *wed_comp_;
+  switch_::Switch *thu_comp_;
+  switch_::Switch *fri_comp_;
+  switch_::Switch *sat_comp_;
+  switch_::Switch *sun_comp_;
+  switch_::Switch *disabled_comp_;
   std::vector<uint8_t> days_of_week_{};
 
   std::vector<uint8_t> flags_to_days_of_week_(
@@ -46,7 +45,8 @@ class DynamicOnTime : public Component {
 
   void update_schedule_();
   optional<ESPTime> next_schedule_{};
-  void init_();
+
+  void reset_trigger_();
 };
 
 }  // namespace dynamic_on_time


### PR DESCRIPTION
* The component now directly inherits from CronTrigger to allow manipulating with its protected/private members. Despite the API might get changed in future, the implementation has better maintainability because of simpler logic.
* There is no user visible changes as the YAML schema and scheduling logic remains the same.