### PR TITLE
fix: Compatibility with ESPHome 2026.4.0

### DIFF
--- a/components/dynamic_on_time/dynamic_on_time.cpp
+++ b/components/dynamic_on_time/dynamic_on_time.cpp
@@ -32,6 +32,14 @@ DynamicOnTime::DynamicOnTime(
 
 void DynamicOnTime::setup() {
     ESP_LOGD(tag, "Setting up component");
+    // Compatibility note:
+    // 
+    // ESPHome <=2026.3.x drove CronTrigger from loop(), but >=2026.4.0 moved
+    // it to setup()-registered interval callbacks (see ESPHome PR #15433 
+    // "[time] Use set_interval for CronTrigger instead of loop()").
+    // Hence, keep this base setup call so trigger checks start and
+    // on_time automations actually fire.
+    time::CronTrigger::setup();
     // Update the configuration initially, ensuring all entities are created
     // before a callback would be delivered to them
     this->update_schedule_();

--- a/components/dynamic_on_time/dynamic_on_time.cpp
+++ b/components/dynamic_on_time/dynamic_on_time.cpp
@@ -35,7 +35,7 @@ void DynamicOnTime::setup() {
     // Compatibility note:
     // 
     // ESPHome <=2026.3.x drove CronTrigger from loop(), but >=2026.4.0 moved
-    // it to setup()-registered interval callbacks (see ESPHome PR #15433 
+    // it to setup()-registered interval callbacks (see ESPHome PR #15433
     // "[time] Use set_interval for CronTrigger instead of loop()").
     // Hence, keep this base setup call so trigger checks start and
     // on_time automations actually fire.

--- a/components/dynamic_on_time/dynamic_on_time.cpp
+++ b/components/dynamic_on_time/dynamic_on_time.cpp
@@ -32,8 +32,6 @@ DynamicOnTime::DynamicOnTime(
 
 void DynamicOnTime::setup() {
     ESP_LOGD(tag, "Setting up component");
-    // Compatibility note:
-    // 
     // ESPHome <=2026.3.x drove CronTrigger from loop(), but >=2026.4.0 moved
     // it to setup()-registered interval callbacks (see ESPHome PR #15433
     // "[time] Use set_interval for CronTrigger instead of loop()").


### PR DESCRIPTION
This fixes the compatibility issue with ESPHome 2026.4.0, where the CronTrigger was moved to setup()-registered interval callbacks (see ESPHome PR [#15433 "[time] Use set_interval for CronTrigger instead of loop()"](https://github.com/esphome/esphome/pull/15433)).
The fix is to call the base setup method so the CronTrigger properly registers the interval callbacks.
Without this fix, the CronTrigger would not start and the on_time automations would not fire.